### PR TITLE
use static `LogzioLambdaExtensionLogs` version

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -71,8 +71,8 @@ jobs:
           aws configure set region ${{ matrix.aws_region }}
       - name: configure layer version in cloudformation template
         run: |
-          ARN=$(aws lambda list-layer-versions --layer-name LogzioLambdaExtensionLogs --region ${{ matrix.aws_region }} --query 'LayerVersions[0].LayerVersionArn') \
-          && sed -i "s/<<LAYER-ARN>>/$ARN/" "./sam-template-${{ matrix.aws_region }}.yaml"
+          LAYER_ARN="arn:aws:lambda:${{ matrix.aws_region }}:486140753397:layer:LogzioLambdaExtensionLogs:19"
+          sed -i "s|<<LAYER-ARN>>|$LAYER_ARN|" "./sam-template-${{ matrix.aws_region }}.yaml"
       - name: Upload to aws
         run: |
           aws s3 cp ./sam-template-${{ matrix.aws_region }}.yaml s3://logzio-aws-integrations-${{ matrix.aws_region }}/api-status-auto-deployment/${{ github.event.release.tag_name }}/sam-template.yaml --acl public-read

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ All metrics that were sent from the Lambda function will have the prefix `api_st
 
 ## Changlog
 
+- **1.1.3**: ci: use static `LogzioLambdaExtensionLogs` version
 - **1.1.2**: Fix layer versions in regions.
 - **1.1.1**: Fix cloudformation template - Lambda layer
 - **1.1.0**: Add geohash to metrics


### PR DESCRIPTION
## Description 

- **1.1.3**: ci: use static `LogzioLambdaExtensionLogs` version

## What type of PR is this?
#### (check all applicable)
- [ ] 🍕 Feature 
- [x] 🐛 Bug Fix
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build / CI
- [ ] ⏩ Revert

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help from somebody
